### PR TITLE
Add header in docstring

### DIFF
--- a/src/MPNLPModels.jl
+++ b/src/MPNLPModels.jl
@@ -403,7 +403,9 @@ function fRelList_test(MList::Vector{M}, ωfRelErr::Vector{H}) where {H,M<:Abstr
   end
 
 """
-Tests dimensions match of MList and ωgRelErr
+    gRelList_test(MList::Vector, ωgRelErr::Vector)
+
+Tests dimensions match of MList and ωgRelErr.
 """
 function gRelList_test(MList::Vector{M}, ωgRelErr::Vector{H}) where {H,M<:AbstractNLPModel}
   err_msg = "MList and ωgRelErr dimension mismatch"


### PR DESCRIPTION
If you add the function header with 4 spaces in front it is showed with a different color.
To test, the docstring:
````
using MultiPrecisionR2
? gRelList_test
```