### PR TITLE
Use @example instead of julia for code in doc

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+IntervalArithmetic = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
 MultiPrecisionR2 = "0956d2b1-8b18-452f-b910-f0f898947302"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,7 +39,8 @@ CurrentModule = MultiPrecisionR2
     4. [Implementation Examples](#implementation-examples)
 
 # Quick Start
-```julia
+
+```@example
 using MultiPrecisionR2
 using ADNLPModels
 using IntervalArithmetic


### PR DESCRIPTION
Hi @d-monnet ! You can use the `@example` block instead of `julia` to actually execute the code in the docs, and then the documentation will also show the result.
If there is more than one cell connected, you can add a name, i.e. `@example ex1` and then also `@example ex1` to the connected cell (so you don't have to do using everywhere.
This way, we know there are no errors in the doc (ps: I tried the first cell and it returned an error).